### PR TITLE
[Docs] upgrade pip before installing packages

### DIFF
--- a/examples/tutorials/openicl_tutorial1_getting_started.ipynb
+++ b/examples/tutorials/openicl_tutorial1_getting_started.ipynb
@@ -6,6 +6,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "%pip install --upgrade pip\n",
     "%pip install openicl\n",
     "# Restart the kernel after the installation is completed"
    ]

--- a/examples/tutorials/openicl_tutorial2_use_different_models.ipynb
+++ b/examples/tutorials/openicl_tutorial2_use_different_models.ipynb
@@ -7,6 +7,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "%pip install --upgrade pip\n",
     "%pip install openicl\n",
     "# Restart the kernel after the installation is completed"
    ]


### PR DESCRIPTION
## Motivation

The default pip version of Colab is too low. Openai needs a higher pip version to install.

## Modification

Added code to automatically upgrade pip before installing packages.